### PR TITLE
Proxy XMLHttpRequest through HTTPS proxy

### DIFF
--- a/src/lib/httpProxy.ts
+++ b/src/lib/httpProxy.ts
@@ -4,21 +4,36 @@
 // served over HTTPS.
 
 const PROXY_BASE =
-        import.meta.env.VITE_HTTP_PROXY || 'https://cors.isomorphic-git.org/';
+  import.meta.env.VITE_HTTP_PROXY || 'https://cors.isomorphic-git.org/';
 
 const originalFetch = globalThis.fetch.bind(globalThis);
 
 globalThis.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
-        let url: string;
-        if (typeof input === 'string') url = input;
-        else if (input instanceof URL) url = input.toString();
-        else url = input.url;
+  let url: string;
+  if (typeof input === 'string') url = input;
+  else if (input instanceof URL) url = input.toString();
+  else url = input.url;
 
-        if (url.startsWith('http://')) {
-                return originalFetch(PROXY_BASE + url, init);
-        }
-        return originalFetch(input as any, init);
+  if (url.startsWith('http://')) {
+    return originalFetch(PROXY_BASE + url, init);
+  }
+  return originalFetch(input as any, init);
 };
+
+// Patch XMLHttpRequest to route insecure requests through the proxy as well
+const originalXHROpen = globalThis.XMLHttpRequest?.prototype.open;
+if (originalXHROpen) {
+  globalThis.XMLHttpRequest.prototype.open = function (
+    method: string,
+    url: string,
+    ...rest: any[]
+  ) {
+    if (typeof url === 'string' && url.startsWith('http://')) {
+      return originalXHROpen.call(this, method, PROXY_BASE + url, ...rest);
+    }
+    return originalXHROpen.call(this, method, url, ...rest);
+  };
+}
 
 export {}; // ensure this file is treated as a module
 


### PR DESCRIPTION
## Summary
- proxy XMLHttpRequest calls through the existing HTTPS proxy to avoid mixed content errors

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 4 errors, 1 warning)*


------
https://chatgpt.com/codex/tasks/task_e_68b3e1a4313483299866fd5c712d72ad