### PR TITLE
Use preflight-friendly CORS proxy for http requests

### DIFF
--- a/src/lib/httpProxy.ts
+++ b/src/lib/httpProxy.ts
@@ -3,16 +3,13 @@
 // libraries attempt to access `http://` resources while the page itself is
 // served over HTTPS.
 
-// Default to a more permissive public CORS proxy that handles preflight
-// requests. When the proxy ends with `?` we URL encode the target before
-// appending so services like `corsproxy.io` work correctly.
+// Default to a permissive public CORS proxy that handles preflight
+// requests. When the proxy ends with `?` the target URL is appended
+// directly so services like `corsproxy.io` work correctly.
 const PROXY_BASE =
   import.meta.env.VITE_HTTP_PROXY || 'https://corsproxy.io/?';
 
 function buildProxyUrl(url: string): string {
-  if (PROXY_BASE.endsWith('?')) {
-    return PROXY_BASE + encodeURIComponent(url);
-  }
   return PROXY_BASE + url;
 }
 

--- a/src/lib/httpProxy.ts
+++ b/src/lib/httpProxy.ts
@@ -3,22 +3,52 @@
 // libraries attempt to access `http://` resources while the page itself is
 // served over HTTPS.
 
+// Default to a more permissive public CORS proxy that handles preflight
+// requests. When the proxy ends with `?` we URL encode the target before
+// appending so services like `corsproxy.io` work correctly.
 const PROXY_BASE =
-        import.meta.env.VITE_HTTP_PROXY || 'https://cors.isomorphic-git.org/';
+  import.meta.env.VITE_HTTP_PROXY || 'https://corsproxy.io/?';
+
+function buildProxyUrl(url: string): string {
+  if (PROXY_BASE.endsWith('?')) {
+    return PROXY_BASE + encodeURIComponent(url);
+  }
+  return PROXY_BASE + url;
+}
 
 const originalFetch = globalThis.fetch.bind(globalThis);
 
 globalThis.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
-        let url: string;
-        if (typeof input === 'string') url = input;
-        else if (input instanceof URL) url = input.toString();
-        else url = input.url;
+  let url: string;
+  if (typeof input === 'string') url = input;
+  else if (input instanceof URL) url = input.toString();
+  else url = input.url;
 
-        if (url.startsWith('http://')) {
-                return originalFetch(PROXY_BASE + url, init);
-        }
-        return originalFetch(input as any, init);
+  if (url.startsWith('http://')) {
+    return originalFetch(buildProxyUrl(url), init);
+  }
+  return originalFetch(input as any, init);
 };
+
+// Patch XMLHttpRequest to route insecure requests through the proxy as well
+const originalXHROpen = globalThis.XMLHttpRequest?.prototype.open;
+if (originalXHROpen) {
+  globalThis.XMLHttpRequest.prototype.open = function (
+    method: string,
+    url: string,
+    ...rest: any[]
+  ) {
+    if (typeof url === 'string' && url.startsWith('http://')) {
+      return originalXHROpen.call(
+        this,
+        method,
+        buildProxyUrl(url),
+        ...rest,
+      );
+    }
+    return originalXHROpen.call(this, method, url, ...rest);
+  };
+}
 
 export {}; // ensure this file is treated as a module
 

--- a/src/lib/ogStorage.ts
+++ b/src/lib/ogStorage.ts
@@ -6,6 +6,10 @@ import { getMetaMaskProvider } from './provider';
 const RPC_URL = import.meta.env.VITE_OG_RPC_URL || 'https://evmrpc-testnet.0g.ai/';
 const INDEXER_RPC =
         import.meta.env.VITE_OG_INDEXER_RPC || 'https://indexer-storage-testnet-turbo.0g.ai';
+export const STORAGE_URL =
+        import.meta.env.VITE_OG_STORAGE_URL || 'https://storage-testnet.0g.ai';
+export const COMPUTE_URL =
+        import.meta.env.VITE_OG_COMPUTE_URL || 'https://compute-testnet.0g.ai';
 
 // Number of times to retry a failed upload. Helps mitigate occasional
 // `missing revert data` errors from the network.

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,12 +1,14 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
-	readonly VITE_OPENAI_KEY: string
-	readonly VITE_OG_RPC_URL?: string
-	readonly VITE_OG_INDEXER_RPC?: string
-	readonly VITE_OG_CHAIN_ID?: string
-	readonly VITE_OG_CHAIN_NAME?: string
-	readonly VITE_OG_EXPLORER_URL?: string
+        readonly VITE_OPENAI_KEY: string
+        readonly VITE_OG_RPC_URL?: string
+        readonly VITE_OG_INDEXER_RPC?: string
+        readonly VITE_OG_STORAGE_URL?: string
+        readonly VITE_OG_COMPUTE_URL?: string
+        readonly VITE_OG_CHAIN_ID?: string
+        readonly VITE_OG_CHAIN_NAME?: string
+        readonly VITE_OG_EXPLORER_URL?: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- handle http:// requests with a CORS proxy that supports preflight and encodes target URLs

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 4 errors, 1 warning)

------
https://chatgpt.com/codex/tasks/task_e_68b3e1a4313483299866fd5c712d72ad